### PR TITLE
 Add option to provide an already generated ssh private key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ script:
   - id testuser109 | grep --silent "testuser109"
   - id testuser110 | grep --silent "testuser110"
   - id testuser111 | grep --silent "testuser111"
+  - id testuser112 | grep --silent "testuser112"
+  - id testuser113 | grep --silent "testuser113"
   - sudo grep testuser101 /etc/shadow | awk -F":" '{exit $2!="$6$/y5RGZnFaD3f$96xVdOAnldEtSxivDY02h.DwPTrJgGQl8/MTRRrFAwKTYbFymeKH/1Rxd3k.RQfpgebM6amLK3xAaycybdc.60"}'
   - sudo grep testuser102 /etc/shadow | awk -F":" '{exit $2!="$6$F/KXFzMa$ZIDqtYtM6sOC3UmRntVsTcy1rnsvw.6tBquOhX7Sb26jxskXpve8l6DYsQyI1FT8N5I5cL0YkzW7bLbSCMtUw1"}'
   - grep --silent "^testuser101:" /etc/group
@@ -69,8 +71,14 @@ script:
   # Check ssh key for user was created
   - sudo cat /home/testuser108/.ssh/id_rsa | grep --silent "BEGIN RSA PRIVATE KEY"
   - sudo cat /home/testuser109/.ssh/id_rsa | grep --silent "BEGIN RSA PRIVATE KEY"
+  - sudo cat /home/testuser113/.ssh/id_rsa | grep --silent "BEGIN RSA PRIVATE KEY"
+  # Check ssh private key for user was created
+  - sudo ssh-keygen -lf /home/testuser112/.ssh/ansible-provisioned_ssh_key | awk '{exit $2!="SHA256:+I447SmJstX5ep1I4lTziPdI9i97PZkg9R1BukZGYio"}'
   # Check no ssh key for user was created
   - sudo test ! -f /home/testuser110/.ssh/id_rsa
+  # Check no ansible-provisioned_ssh_key was created but id_rsa was
+  - sudo test -f /home/testuser113/.ssh/id_rsa
+  - sudo test ! -f /home/testuser113/.ssh/ansible-provisioned_ssh_key
   # Check key is encrypted
   - sudo cat /home/testuser109/.ssh/id_rsa | grep --silent "ENCRYPTED"
   # Check key size is correct

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,8 @@ script:
   # Confirm ssh key was changed and only 1 entry in file
   - sudo grep --silent "^ssh-rsa AAABNEW.... test104@server" /home/testuser104/.ssh/authorized_keys
   - sudo cat /home/testuser104/.ssh/authorized_keys | wc -l | grep --silent "1"
+  # Confirm ssh private key (ansible-provisioned_ssh_key) for user was changed
+  - sudo ssh-keygen -lf /home/testuser112/.ssh/ansible-provisioned_ssh_key | awk '{exit $2!="SHA256:YpTwoSg4oG6qbhwVv55wlJ+Ny/hkwNVa39sT6y7hyzw"}'
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ File Location: vars/secret
 * **ssh_key_bits**: Optionally specify number of bits in SSH key to create. (optional, default set by ssh-keygen)
 * **ssh_key_passphrase**: Set a passphrase for the SSH key. If no passphrase is provided, the SSH key will default to having no passphrase.
 * **generate_ssh_key_comment**: Specify the comment for the generated SSH key (optional). If not specified, will use default_generate_ssh_key_comment from defaults yaml.
+* **ssh_private_key**: Set an already generated private key. The key will be placed in *~/.ssh/ansible-provisioned_ssh_key*. If a key with this name already exists, it will be replaced. It is recommended to retrieve the value from a vault. (optional) 
 * **use_sudo**: yes|no (optional, default no)
 * **use_sudo_nopass**: yes|no (optional, default no). yes = passwordless sudo.
 * **system**: yes|no (optional, default no). yes = create system account (uid < 1000). Does not work on existing users.
@@ -199,6 +200,21 @@ users:
     ssh_key: ssh-rsa AAAB.... test107@server
     generate_ssh_key: yes
     ssh_key_bits: 4096
+    use_sudo: no
+    user_state: lock
+    servers:
+      - webserver
+      - database
+  
+  - username: testuser106
+    password: $6$XEnyI5UYSw$Rlc6tXtECtqdJ3uFitrbBlec1/8Fx2obfgFST419ntJqaX8sfPQ9xR7vj7dGhQsfX8zcSX3tumzR7/vwlIH6p/
+    ssh_key: ssh-rsa AAAB.... test107@server
+    ssh_private_key: |
+      -----BEGIN OPENSSL PRIVATE KEY-----
+      MIIJJgIBAAKCAgEAy3pYxxWQqgLPASUFC/eWVQSNQbwpb6tFMv6xcNnAHEvKpV/U
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      hYyF3/iEM1t16QMtescPAieJ9ysSljOWb1MIPzdN9cCX7PQ/DmyHWU7M
+      -----END OPENSSL PRIVATE KEY-----
     use_sudo: no
     user_state: lock
     servers:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ File Location: vars/secret
 * **ssh_key_bits**: Optionally specify number of bits in SSH key to create. (optional, default set by ssh-keygen)
 * **ssh_key_passphrase**: Set a passphrase for the SSH key. If no passphrase is provided, the SSH key will default to having no passphrase.
 * **generate_ssh_key_comment**: Specify the comment for the generated SSH key (optional). If not specified, will use default_generate_ssh_key_comment from defaults yaml.
-* **ssh_private_key**: Set an already generated private key. The key will be placed in *~/.ssh/ansible-provisioned_ssh_key*. If a key with this name already exists, it will be replaced. It is recommended to retrieve the value from a vault. (optional) 
+* **ssh_private_key**: Set an already generated private key. The key will be placed in *~/.ssh/ansible-provisioned_ssh_key*. If a key with this name already exists, it will be replaced. If *generate_ssh_key* is defined this parameter is ignored. It is recommended to retrieve the value from a vault. (optional) 
 * **use_sudo**: yes|no (optional, default no)
 * **use_sudo_nopass**: yes|no (optional, default no). yes = passwordless sudo.
 * **system**: yes|no (optional, default no). yes = create system account (uid < 1000). Does not work on existing users.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,16 @@
   debug: var=users
   when: debug_enabled_default | bool
 
+- name: set_fact | get default home dir
+  ansible.builtin.shell:
+    cmd: "grep 'HOME=' /etc/default/useradd | cut -d= -f2"
+  register: homedir
+  changed_when: false
+
+- name: debug homedir.stdout variable
+  debug: var=homedir.stdout
+  when: debug_enabled_default | bool
+
 - name: Add group | create primary group before adding user to group
   group:
     name: "{{ item.primarygroup }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -172,7 +172,7 @@
 
 - name: SSH Keys | Add private key
   copy:
-    dest: "{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible_ssh_key"
+    dest: "{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible-provisioned_ssh_key"
     mode: '0600'
     owner: "{{ item.username }}"
     group: "{{ item.primarygroup | default(omit)}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,7 +160,7 @@
 
 - name: SSH Keys | Add private key
   copy:
-    dest: ~/.ssh/id_rsa
+    dest: "/{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible_ssh_key"
     mode: '0600'
     force: true
     content: "{{ item.ssh_private_key }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -156,6 +156,20 @@
   loop_control:
     label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_key_bits: {{ item.ssh_key_bits if item.ssh_key_bits is defined else '' }}, ssh_key_passphrase: {{ 'True' if item.ssh_key_passphrase is defined else 'False' }}, generate_ssh_key_comment: {{ item.generate_ssh_key_comment if item.generate_ssh_key_comment is defined else default_generate_ssh_key_comment }}"
 
+#TODO: Ensure ~/.ssh exists
+
+- name: SSH Keys | Add private key
+  copy:
+    dest: ~/.ssh/id_rsa
+    mode: '0600'
+    force: true
+    content: "{{ item.ssh_private_key }}"
+  when: item.ssh_private_key is defined and item.generate_ssh_key is not defined and item.servers | intersect(create_users_group_names)
+  loop: '{{ users }}'
+  loop_control:
+    label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_private_key: {{ 'True' if item.ssh_private_key is defined else 'False' }}"
+
+
 - name: Sudo | add to sudoers file and validate
   lineinfile:
     dest: /etc/sudoers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
   debug: var=users
   when: debug_enabled_default | bool
 
+# Retrieve $HOME from /etc/default/useradd
 - name: set_fact | get default home dir
   ansible.builtin.shell:
     cmd: "grep 'HOME=' /etc/default/useradd | cut -d= -f2"
@@ -156,19 +157,31 @@
   loop_control:
     label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_key_bits: {{ item.ssh_key_bits if item.ssh_key_bits is defined else '' }}, ssh_key_passphrase: {{ 'True' if item.ssh_key_passphrase is defined else 'False' }}, generate_ssh_key_comment: {{ item.generate_ssh_key_comment if item.generate_ssh_key_comment is defined else default_generate_ssh_key_comment }}"
 
-#TODO: Ensure ~/.ssh exists
+#Ensure ~/.ssh exists
+- name: SSH Keys | Ensure ~/.ssh folder exists
+  file:
+    path: "{{ homedir.stdout }}/{{ item.username }}/.ssh"
+    owner: "{{ item.username }}"
+    group: "{{ item.primarygroup | default(omit)}}"
+    mode: "0700"
+    state: "directory"
+  when: item.ssh_private_key is defined and item.generate_ssh_key is not defined and item.servers | intersect(create_users_group_names)
+  loop: '{{ users }}'
+  loop_control:
+    label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_private_key: {{ 'True' if item.ssh_private_key is defined else 'False' }}"
 
 - name: SSH Keys | Add private key
   copy:
     dest: "{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible_ssh_key"
     mode: '0600'
+    owner: "{{ item.username }}"
+    group: "{{ item.primarygroup | default(omit)}}"
     force: true
     content: "{{ item.ssh_private_key }}"
   when: item.ssh_private_key is defined and item.generate_ssh_key is not defined and item.servers | intersect(create_users_group_names)
   loop: '{{ users }}'
   loop_control:
     label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_private_key: {{ 'True' if item.ssh_private_key is defined else 'False' }}"
-
 
 - name: Sudo | add to sudoers file and validate
   lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,7 +160,7 @@
 
 - name: SSH Keys | Add private key
   copy:
-    dest: "/{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible_ssh_key"
+    dest: "{{ homedir.stdout }}/{{ item.username }}/.ssh/ansible_ssh_key"
     mode: '0600'
     force: true
     content: "{{ item.ssh_private_key }}"

--- a/tests/test-passchange.yml
+++ b/tests/test-passchange.yml
@@ -87,5 +87,52 @@
         servers:
           - database
 
+      # Test if ssh_private_key is overide
+      - username: testuser112
+        user_state: present
+        ssh_private_key: |
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+          NhAAAAAwEAAQAAAYEAldqksAedFAzsDlnye3mIOA7kkY+f9Z1mBGGa44ZXGGWxX4xjIPYh
+          EliMXzeSUv9qydAXvvdZnRLlqfQxY5X9/GKgxSkfRYCXcK8+iZRYeCNYdD0j1oIWNc7nWh
+          km0VurN8y5KqPuzlUCpW/fBPT42U0N63pc0lQsom/NCou34dJWOyNJWkoeuCwFczJ/Ibu/
+          7hwR9wMCq64gNRcEeotNyD6UPHxTlZUQXXqQbKw6Avzi1SVxTauthFmYnYd3uH8P/Nl7/V
+          EhdD4N6jvEWG2fs56wT2wTb60ZULoWcfiFlsyzat0J1lBJKIz6f/qd0KInJiZl1mM3TPej
+          K8rJnYLqIMHlvvvJu/d8H3as6iwOhH/SW8V7Kyrr6cTSWIgqAlZNIGYSdTbOrzD1sEg7Dh
+          fulICJ1KmBXWhy9h41pj0umtgJEONsMpax5kuKGEKBTXmmC6WmXH2UV3XuWxf5RL989Cp7
+          NpYR1OQWmKD8QSiPpaDXbi/nUycxdtT0zGjzPjBDAAAFiOyWSMXslkjFAAAAB3NzaC1yc2
+          EAAAGBAJXapLAHnRQM7A5Z8nt5iDgO5JGPn/WdZgRhmuOGVxhlsV+MYyD2IRJYjF83klL/
+          asnQF773WZ0S5an0MWOV/fxioMUpH0WAl3CvPomUWHgjWHQ9I9aCFjXO51oZJtFbqzfMuS
+          qj7s5VAqVv3wT0+NlNDet6XNJULKJvzQqLt+HSVjsjSVpKHrgsBXMyfyG7v+4cEfcDAquu
+          IDUXBHqLTcg+lDx8U5WVEF16kGysOgL84tUlcU2rrYRZmJ2Hd7h/D/zZe/1RIXQ+Deo7xF
+          htn7OesE9sE2+tGVC6FnH4hZbMs2rdCdZQSSiM+n/6ndCiJyYmZdZjN0z3oyvKyZ2C6iDB
+          5b77ybv3fB92rOosDoR/0lvFeysq6+nE0liIKgJWTSBmEnU2zq8w9bBIOw4X7pSAidSpgV
+          1ocvYeNaY9LprYCRDjbDKWseZLihhCgU15pgulplx9lFd17lsX+US/fPQqezaWEdTkFpig
+          /EEoj6Wg124v51MnMXbU9Mxo8z4wQwAAAAMBAAEAAAGAJqI30yojVQf/07Nc0HiEpe8w/l
+          YI50mtA3QmeoIn8iJFmFyZMeZCoHgzuFibYMp4vY7okFM0x0oX67kJAqOo12iWCj6P0VtV
+          r7d+Z/nW1SJHq7AXjTX8g+LTwma5m0AG5FvjYRridk90XzJ4TM7bWSqEbDEfvRn2Z+pq8k
+          0TGyUfFiACyURSpyiyPwDFxeyhjsGt4ADmr1w08Xr9rJo9c2Ku1Ok4o1fK4E647Ut5qUuJ
+          L2p3y453LafrsLE8LFSVZZXz39JJIGAVVUeUW55igx+c8jeWogoDY3OUqPPxhCmfMHWCQV
+          HnoyyzPKln0eW44JARr4iRghdbVktNcDs8IWb+Rcb7TfwAu313RN7RAc5yqrXx2INbrac0
+          EAplOfavRRJyhxe2TxzEtliCGfpguKkwqkiSu9OFaargeXKVy6HVOE9ywzwEx8iUM5C2jk
+          L/3dbxRP+c1m5xtQChnRJF6uN2VgJIOo1T9dkiXoIL1PwVtQb2uuNoO2kCT43+EKABAAAA
+          wFNLLa07xmzNFJIDBuOG92P71R/AUEEDOT/nREc3UoRxOk3c6aoXwUegKI01A+/ym6E4pe
+          vjaixydKDUqCDOxGEnv8WKZ2J0EaQXsMuUPq+pm9N0ya++afSB6ChrXuhFnMnEO2g2XXRj
+          3BmhACyhEvYgJ4ZRMlzSulHzRvdNwGt7sW3jF0ipWQylES2xsMPLXtK4QKseuvuRiz/igb
+          Ps0PmfCpAfVvJ2QEOo4Ye9cb2t+vTVs3p1UGcPL6sobyiJ4gAAAMEAyF804ZsvO6Ok9PZu
+          BSRHtc/UPncS+EhzOcWuih14JpbhTLKN/Fh0Dhx2FEQMVziNyO8RPeP6YUn8/IPK1ZfrUj
+          VMIIDAYzxTugBZsQg1YSIGePtmRVDUpDrt3FAV1lze2G7Iw95oUo/UzJOhFBSUCztYf56Q
+          Tqz4Ymq/Azd8HKhPQfijS8sOoZOUFOV/RLKR2kvgQlkY2a/+oeZP1fgjoFfCapG3sSUGsk
+          yQGFEoqIqxTjckfv0ZISgMuUW3FdurAAAAwQC/dQskWDwexENNE0B1bUA2BK1AKTs6xv2k
+          qtQUVNVQxMzfyq9iY9Fj1A518iL//sTnv0vf21fpHqhm7y5dHq/T1dEu4scW7GOtP0DDeN
+          mdElWvv/O1h9h361Ixk2SXMBQp4RyzISqfP9vAWoi6EQJ9e9ba9p+JTeJgi41b8hKFGeUM
+          bBJQwNmDi+aOcLu/LacW0sHMy7owBshmAc3Ux8na9ChpOEHx9xWrdvbz7RBWLb6Xx5z7hq
+          diBS75rbH/JckAAAASdGVzdF9wcml2YXRlX2tleUAyAQ==
+          -----END OPENSSH PRIVATE KEY-----
+        servers:
+          - webserver
+          - database
+          - monitoring
+
   roles:
     - ansible-role-create-users

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -122,6 +122,100 @@
           - webserver
           - database
           - monitoring
+      
+      # Test if ssh_private_key is added in ~/.ssh/ansible-provisioned_ssh_key
+      - username: testuser112
+        user_state: present
+        ssh_private_key: |
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+          NhAAAAAwEAAQAAAYEAkHainYOxlw4rXo5JyoynGrz+/vlKEF+bqyOW7qCHkpGdKYfpjOMu
+          Cehscpy4IF6cZoGpXxePna/8mowljFW61NRXr3EfOFjTVHEiEntpLy8xCTsDjslmgw6FS2
+          kow55+VtqSUApfz4J2KIgnLMcwRJr7ya4tpLchaL3M6oY6wftxuBwfgTT3T+PRURKeH38a
+          X8fKxWcXSB5m+5a+x4pM3aS72PrkbiEbUb0X+9YVTYx+7EZ1un7jlwh8rj0Qh3AeNRFGTp
+          O0mvd43zH/yDRfpbv+D1wzDqzWyHD1/AEVXa69T8jWNgkOXgLp9K6JTrIeWd8ZeSvxYthm
+          2a8IvW66WQihjna0X5H8QPgo/Edb15oew6yRjOJXrm/R1+4xbrSl73QGxY13KKTN8BriJt
+          uHKUmFT3y8Cbeg7CG2zSxDyj+ugXDbn2rxUOuNPUidNz7G2gv97yHPeIiMTA6Sr0HMn3gT
+          YTn0ArCeNXv/3tFeOq7eeFcqc26qkVjo9iqRdzUbAAAFiLXSqMa10qjGAAAAB3NzaC1yc2
+          EAAAGBAJB2op2DsZcOK16OScqMpxq8/v75ShBfm6sjlu6gh5KRnSmH6YzjLgnobHKcuCBe
+          nGaBqV8Xj52v/JqMJYxVutTUV69xHzhY01RxIhJ7aS8vMQk7A47JZoMOhUtpKMOeflbakl
+          AKX8+CdiiIJyzHMESa+8muLaS3IWi9zOqGOsH7cbgcH4E090/j0VESnh9/Gl/HysVnF0ge
+          ZvuWvseKTN2ku9j65G4hG1G9F/vWFU2MfuxGdbp+45cIfK49EIdwHjURRk6TtJr3eN8x/8
+          g0X6W7/g9cMw6s1shw9fwBFV2uvU/I1jYJDl4C6fSuiU6yHlnfGXkr8WLYZtmvCL1uulkI
+          oY52tF+R/ED4KPxHW9eaHsOskYziV65v0dfuMW60pe90BsWNdyikzfAa4ibbhylJhU98vA
+          m3oOwhts0sQ8o/roFw259q8VDrjT1InTc+xtoL/e8hz3iIjEwOkq9BzJ94E2E59AKwnjV7
+          /97RXjqu3nhXKnNuqpFY6PYqkXc1GwAAAAMBAAEAAAGAENvHXlpf/yDILuCr+9cuKRClMV
+          wmKIL/x5j/pBlXuOMFVDNoLejVFpLpFPb1BdIErnGzMkWtnNlMwTxZpWbbxrqBARhSbGDx
+          SIlrUHzWaYs4Tbt1TtRyAhlPtN0wxKNaWwhmyrBrPewbnd9FsxQLrfXoLEEHUpGMdIyxvS
+          ys7rZJLxMZGhr0QX50juF9Um+ixEqsfxzouqHRosqUuPSKw9LVmRyuS6vRZFiM0/bHxaT/
+          qtMOKhVkudtjsXGu3B9ZOiu7u/Gykju9JME232z8nanpESD9M5yq8V60ovoMvJ8Xg+fpxM
+          lGnZEjlfI9/EZt9v8/PTYa/MRcLHEb1YBin0tOhyBWiTxHBAoscDThxW/qWIgNWszbrnw0
+          yzHx9dT3Kps6xCsLqQUfs/4VbLURsaQ4De3O55UpV1GkzvEXxanWxnPK7zFX20MmWvt56A
+          qfTfUzkz0YQz4huPqI3NTJU0PMsObgPOLa8/4UjTIiVUwtnYNy38Pga705+u7JPusBAAAA
+          wGt3n8W2hpvqYkiaEjeQwtUskoxrG2W/uhsRX5BYNxUkj7wiXAlAiyBmI+APpKSymMHz42
+          Hh3C9e84HaoqVphYmKPjMiDUcO7tWgV7i7z9s5svv5BXo6teZgkyaP/CqZPtH2SqVJY6Jh
+          NS/yXRl9baKhvVhVn8QPubFFpsdP/y7DCO1mRq7FxlmIRl3p0HVIIC7rx+n5tEgy+rwNcb
+          Pk14qcaE405TQ0fstDCO1MlH4SFyew7PA1Pb0sl8up1Sa6rwAAAMEAuHToBLBhywc6Kicm
+          4L1ya9bhnCxvBziy4iTS3kSefWfDw3y0WHoe2ytrwfSvPjMn0ngsr/5aChYTbt32YofHN/
+          7p18GL8TcN6KveWdPdth1RRQxCaoOoqjspPndEqmWJxpGk9AgOQkh+aFoOFF7CP+YtOJnE
+          cesK0U7895ri8H8RkWePeboZGal5bUCBguYw/fcgS472SMD9O1WLYXiTVYEYl2ZtgYKlkR
+          WoX475XCNlhaJitkEU20gZ/xRk5Vn3AAAAwQDIfrbvdqdMyBkzfZrB2Igu9xhU27zpqtDz
+          5i3FaXYeAb+bT/WGKMvvTUdVV7Y7MX+4O1XgB0qqL9E/huMBDcYm/51ju6m3oicaqxINhR
+          migI8WHFz2pbJivJUSRtG6b+FDC/nwY6zHzqEqo5e6TbFoHnedpxcCxqoJ2lp77leFFEfF
+          6JTiVZAHOXRG3aKMkAnKQc1KHKOebWrxyQip+1xd4HzF9TpUFq34LltneIB4TT/akfSebM
+          Z14GqKm+zqFP0AAAASdGVzdF9wcml2YXRlX2tleUAxAQ==
+          -----END OPENSSH PRIVATE KEY-----
+        servers:
+          - webserver
+          - database
+          - monitoring
 
+        # Test if ssh_private_key is ignored when generate_ssh_key is defined
+      - username: testuser113
+        user_state: present
+        generate_ssh_key: yes
+        ssh_private_key: |
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+          NhAAAAAwEAAQAAAYEAkHainYOxlw4rXo5JyoynGrz+/vlKEF+bqyOW7qCHkpGdKYfpjOMu
+          Cehscpy4IF6cZoGpXxePna/8mowljFW61NRXr3EfOFjTVHEiEntpLy8xCTsDjslmgw6FS2
+          kow55+VtqSUApfz4J2KIgnLMcwRJr7ya4tpLchaL3M6oY6wftxuBwfgTT3T+PRURKeH38a
+          X8fKxWcXSB5m+5a+x4pM3aS72PrkbiEbUb0X+9YVTYx+7EZ1un7jlwh8rj0Qh3AeNRFGTp
+          O0mvd43zH/yDRfpbv+D1wzDqzWyHD1/AEVXa69T8jWNgkOXgLp9K6JTrIeWd8ZeSvxYthm
+          2a8IvW66WQihjna0X5H8QPgo/Edb15oew6yRjOJXrm/R1+4xbrSl73QGxY13KKTN8BriJt
+          uHKUmFT3y8Cbeg7CG2zSxDyj+ugXDbn2rxUOuNPUidNz7G2gv97yHPeIiMTA6Sr0HMn3gT
+          YTn0ArCeNXv/3tFeOq7eeFcqc26qkVjo9iqRdzUbAAAFiLXSqMa10qjGAAAAB3NzaC1yc2
+          EAAAGBAJB2op2DsZcOK16OScqMpxq8/v75ShBfm6sjlu6gh5KRnSmH6YzjLgnobHKcuCBe
+          nGaBqV8Xj52v/JqMJYxVutTUV69xHzhY01RxIhJ7aS8vMQk7A47JZoMOhUtpKMOeflbakl
+          AKX8+CdiiIJyzHMESa+8muLaS3IWi9zOqGOsH7cbgcH4E090/j0VESnh9/Gl/HysVnF0ge
+          ZvuWvseKTN2ku9j65G4hG1G9F/vWFU2MfuxGdbp+45cIfK49EIdwHjURRk6TtJr3eN8x/8
+          g0X6W7/g9cMw6s1shw9fwBFV2uvU/I1jYJDl4C6fSuiU6yHlnfGXkr8WLYZtmvCL1uulkI
+          oY52tF+R/ED4KPxHW9eaHsOskYziV65v0dfuMW60pe90BsWNdyikzfAa4ibbhylJhU98vA
+          m3oOwhts0sQ8o/roFw259q8VDrjT1InTc+xtoL/e8hz3iIjEwOkq9BzJ94E2E59AKwnjV7
+          /97RXjqu3nhXKnNuqpFY6PYqkXc1GwAAAAMBAAEAAAGAENvHXlpf/yDILuCr+9cuKRClMV
+          wmKIL/x5j/pBlXuOMFVDNoLejVFpLpFPb1BdIErnGzMkWtnNlMwTxZpWbbxrqBARhSbGDx
+          SIlrUHzWaYs4Tbt1TtRyAhlPtN0wxKNaWwhmyrBrPewbnd9FsxQLrfXoLEEHUpGMdIyxvS
+          ys7rZJLxMZGhr0QX50juF9Um+ixEqsfxzouqHRosqUuPSKw9LVmRyuS6vRZFiM0/bHxaT/
+          qtMOKhVkudtjsXGu3B9ZOiu7u/Gykju9JME232z8nanpESD9M5yq8V60ovoMvJ8Xg+fpxM
+          lGnZEjlfI9/EZt9v8/PTYa/MRcLHEb1YBin0tOhyBWiTxHBAoscDThxW/qWIgNWszbrnw0
+          yzHx9dT3Kps6xCsLqQUfs/4VbLURsaQ4De3O55UpV1GkzvEXxanWxnPK7zFX20MmWvt56A
+          qfTfUzkz0YQz4huPqI3NTJU0PMsObgPOLa8/4UjTIiVUwtnYNy38Pga705+u7JPusBAAAA
+          wGt3n8W2hpvqYkiaEjeQwtUskoxrG2W/uhsRX5BYNxUkj7wiXAlAiyBmI+APpKSymMHz42
+          Hh3C9e84HaoqVphYmKPjMiDUcO7tWgV7i7z9s5svv5BXo6teZgkyaP/CqZPtH2SqVJY6Jh
+          NS/yXRl9baKhvVhVn8QPubFFpsdP/y7DCO1mRq7FxlmIRl3p0HVIIC7rx+n5tEgy+rwNcb
+          Pk14qcaE405TQ0fstDCO1MlH4SFyew7PA1Pb0sl8up1Sa6rwAAAMEAuHToBLBhywc6Kicm
+          4L1ya9bhnCxvBziy4iTS3kSefWfDw3y0WHoe2ytrwfSvPjMn0ngsr/5aChYTbt32YofHN/
+          7p18GL8TcN6KveWdPdth1RRQxCaoOoqjspPndEqmWJxpGk9AgOQkh+aFoOFF7CP+YtOJnE
+          cesK0U7895ri8H8RkWePeboZGal5bUCBguYw/fcgS472SMD9O1WLYXiTVYEYl2ZtgYKlkR
+          WoX475XCNlhaJitkEU20gZ/xRk5Vn3AAAAwQDIfrbvdqdMyBkzfZrB2Igu9xhU27zpqtDz
+          5i3FaXYeAb+bT/WGKMvvTUdVV7Y7MX+4O1XgB0qqL9E/huMBDcYm/51ju6m3oicaqxINhR
+          migI8WHFz2pbJivJUSRtG6b+FDC/nwY6zHzqEqo5e6TbFoHnedpxcCxqoJ2lp77leFFEfF
+          6JTiVZAHOXRG3aKMkAnKQc1KHKOebWrxyQip+1xd4HzF9TpUFq34LltneIB4TT/akfSebM
+          Z14GqKm+zqFP0AAAASdGVzdF9wcml2YXRlX2tleUAxAQ==
+          -----END OPENSSH PRIVATE KEY-----
+        servers:
+          - webserver
+          - database
+          - monitoring
   roles:
     - ansible-role-create-users


### PR DESCRIPTION
I have a use case where I have a private ssh key that is already generated - the public key is already install on the servers - and need it to be provisioned by Ansible.

So I've added the ssh_private_key parameter that allows to do so. Obviously, it's recommended to put the private key content in a vault.
The private key is placed in ~/.ssh/ansible-provisioned_ssh_key.
The parameter is ignored if generate_ssh_key is defined (both are not incompatible, but I thought it made more sense this way).
The tests have been implemented.

Even if the use case is specific, I thought it could help others :)
